### PR TITLE
Replace legacy logo images with text treatment

### DIFF
--- a/cl-doubled-revenue-study.html
+++ b/cl-doubled-revenue-study.html
@@ -4,41 +4,16 @@
         
         <title>Breaking Through Conversion Plateaus: A Strategic UX Success Story | Roan Crabb</title>
         <meta charset="utf-8">
-        <meta name="description" content="Discover how we helped a lending platform break through their conversion ceiling, doubling revenue while reducing acquisition costs through strategic UX and customer journey optimization.">
+        <meta name="description" content="Discover how I helped a lending platform break through its conversion ceiling, doubling revenue while reducing acquisition costs through strategic UX and customer journey optimization.">
 
         <!-- Open Graph Tags -->
         <meta property="og:title" content="Breaking Through the Digital Ceiling: Strategic UX Doubles Lending Platform Revenue | Roan Crabb">
-        <meta property="og:description" content="When your landing pages are already optimized and you're spending $25k daily on paid traffic, finding new growth seems impossible. See how we transformed a lending platform's approach through strategic UX and customer education.">
+        <meta property="og:description" content="When your landing pages are already optimized and you're spending $25k daily on paid traffic, finding new growth seems impossible. See how I transformed a lending platform's approach through strategic UX and customer education.">
         <meta property="og:type" content="article">
         <meta property="og:locale" content="en_US">
 
         <!-- Additional Meta Tags -->
         <meta name="keywords" content="conversion rate optimization, lending platform UX, financial services design, customer journey optimization, landing page optimization, financial UX strategy, conversion optimization, customer education design">
-
-        <!-- Schema Markup -->
-        <script type="application/ld+json">
-        {
-        "@context": "https://schema.org",
-        "@type": "CaseStudy",
-        "name": "Breaking Through the Digital Ceiling: Strategic UX Doubles Platform Revenue",
-        "description": "How we helped a lending platform transform their conversion approach through strategic UX and customer education, doubling revenue while building sustainable growth.",
-        "industry": "Financial Services",
-        "primaryTopic": "Conversion Optimization",
-        "author": {
-            "@type": "Organization",
-            "name": "Roan Crabb"
-        },
-        "result": {
-            "@type": "ResultsData",
-            "metrics": [
-                "2X revenue growth in 6 months",
-                "40% reduction in acquisition costs",
-                "35% increase in 90-day retention",
-                "85% increase in customer lifetime value"
-            ]
-        }
-        }
-        </script>
 
         <!--[if IE]><meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1'><![endif]-->
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -79,7 +54,7 @@
                     <!-- Logo ( * your text or image into link tag *) -->
                     <div class="nav-logo-wrap local-scroll">
                         <a href="index.html" class="logo morphing-text">
-                            <img src="images/logo-white.png" alt="Roan Crabb" width="188" height="37" />
+                            R&nbsp;&nbsp;&nbsp;O&nbsp;&nbsp;&nbsp;A&nbsp;&nbsp;&nbsp;N
                         </a>
                     </div>
                     
@@ -93,9 +68,9 @@
                     <div class="inner-nav desktop-nav">
                         <ul class="clearlist scroll-nav local-scroll">
                             <li class="active"><a href="index.html">Home</a></li>
-                            <li><a href="index.html#services">Our Services</a></li>
-                            <li><a href="index.html#work">Our Work</a></li>
-                            <li><a href="index.html#contact">Contact Us</a></li>
+                            <li><a href="index.html#services">What I Do</a></li>
+                            <li><a href="index.html#work">What I Make</a></li>
+                            <li><a href="index.html#contact">Contact</a></li>
                         </ul>
                     </div>
                     <!-- End Main Menu -->                    

--- a/cl-organic-foundation-study.html
+++ b/cl-organic-foundation-study.html
@@ -1,46 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
-    <title>From PPC Dependency to Organic Dominance | Roan Crabb</title>
-    <meta charset="utf-8">
-    <meta name="description" content="How I built a repeatable UX & content framework that increased revenue 325% across multiple financial brands. A case study in transforming from PPC dependency to organic dominance.">
+    <head>
+        <title>From PPC Dependency to Organic Dominance | Roan Crabb</title>
+        <meta charset="utf-8">
+        <meta name="description" content="How I built a repeatable UX & content framework that increased revenue 325% across multiple financial brands. A case study in transforming from PPC dependency to organic dominance.">
     
-    <!-- Open Graph Tags -->
-    <meta property="og:title" content="From PPC Dependency to Organic Dominance: 325% Revenue Growth | Roan Crabb">
-    <meta property="og:description" content="Discover how I transformed a 20-year-old financial platform through strategic UX and content architecture, creating a repeatable framework for organic growth.">
-    <meta property="og:type" content="article">
-    <meta property="og:locale" content="en_US">
+        <!-- Open Graph Tags -->
+        <meta property="og:title" content="From PPC Dependency to Organic Dominance: 325% Revenue Growth | Roan Crabb">
+        <meta property="og:description" content="Discover how I transformed a 20-year-old financial platform through strategic UX and content architecture, creating a repeatable framework for organic growth.">
+        <meta property="og:type" content="article">
+        <meta property="og:locale" content="en_US">
     
-    <!-- Additional Meta Tags -->
-    <meta name="keywords" content="UX strategy, content marketing, organic growth, financial services UX, conversion optimization, PPC alternatives, digital transformation">
+        <!-- Additional Meta Tags -->
+        <meta name="keywords" content="UX strategy, content marketing, organic growth, financial services UX, conversion optimization, PPC alternatives, digital transformation">
     
-    <!-- Schema Markup -->
-    <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "CaseStudy",
-        "name": "From PPC Dependency to Organic Dominance",
-        "description": "How I built a repeatable UX & content framework that increased revenue 325% across multiple brands",
-        "industry": "Financial Services",
-        "primaryTopic": "Digital Transformation",
-        "author": {
-            "@type": "Person",
-            "name": "Roan Crabb"
-        },
-        "result": {
-            "@type": "ResultsData",
-            "metrics": [
-                "325% increase in revenue",
-                "337% increase in transactions",
-                "140% improvement in conversions",
-                "70,000+ keywords ranked"
-            ]
-        }
-    }
-    </script>
-
         <!--[if IE]><meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1'><![endif]-->
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        
+
         <!-- Favicons -->
         <link rel="shortcut icon" href="images/favicon.png">
 
@@ -53,7 +29,7 @@
         <link rel="stylesheet" href="css/owl.carousel.css">
         <link rel="stylesheet" href="css/animate.min.css">
         <link rel="stylesheet" href="css/splitting.css">
-        
+
     </head>
         <body class="appear-animate case-study">
         
@@ -77,7 +53,7 @@
                     <!-- Logo ( * your text or image into link tag *) -->
                     <div class="nav-logo-wrap local-scroll">
                         <a href="index.html" class="logo morphing-text">
-                            <img src="images/logo-white.png" alt="Roan Crabb" width="188" height="37" />
+                            R&nbsp;&nbsp;&nbsp;O&nbsp;&nbsp;&nbsp;A&nbsp;&nbsp;&nbsp;N
                         </a>
                     </div>
                     
@@ -91,9 +67,9 @@
                     <div class="inner-nav desktop-nav">
                         <ul class="clearlist scroll-nav local-scroll">
                             <li class="active"><a href="index.html">Home</a></li>
-                            <li><a href="index.html#services">Our Services</a></li>
-                            <li><a href="index.html#work">Our Work</a></li>
-                            <li><a href="index.html#contact">Contact Us</a></li>
+                            <li><a href="index.html#services">What I Do</a></li>
+                            <li><a href="index.html#work">What I Make</a></li>
+                            <li><a href="index.html#contact">Contact</a></li>
                         </ul>
                     </div>
                     <!-- End Main Menu -->                    

--- a/gen-ai-healthcare-support-bot-study.html
+++ b/gen-ai-healthcare-support-bot-study.html
@@ -1,46 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
-    <title>From 24 Hours to 2 Minutes: How a Scrappy Team of 6 Built Healthcare's AI Future | Roan Crabb</title>
-    <meta charset="utf-8">
-    <meta name="description" content="Discover how I worked with AWS & Anthropic to help architect and steer an entire organization's AI trajectory, transforming healthcare support and unlocking millions in funding.">
+    <head>
+        <title>From 24 Hours to 2 Minutes: How a Scrappy Team of 6 Built Healthcare's AI Future | Roan Crabb</title>
+        <meta charset="utf-8">
+        <meta name="description" content="Discover how I worked with AWS & Anthropic to help architect and steer an entire organization's AI trajectory, transforming healthcare support and unlocking millions in funding.">
 
-    <!-- Open Graph Tags -->
-    <meta property="og:title" content="Healthcare's AI Transformation: How 6 People Changed an Enterprise | Roan Crabb">
-    <meta property="og:description" content="See how a scrappy team built healthcare's first AI support system, triggering a company-wide pivot to AI-first development and securing AWS as a strategic partner.">
-    <meta property="og:type" content="article">
-    <meta property="og:locale" content="en_US">
+        <!-- Open Graph Tags -->
+        <meta property="og:title" content="Healthcare's AI Transformation: How 6 People Changed an Enterprise | Roan Crabb">
+        <meta property="og:description" content="See how I led a scrappy team to build healthcare's first AI support system, triggering a company-wide pivot to AI-first development and securing AWS as a strategic partner.">
+        <meta property="og:type" content="article">
+        <meta property="og:locale" content="en_US">
 
-    <!-- Additional Meta Tags -->
-    <meta name="keywords" content="healthcare AI, AWS Bedrock, Anthropic Claude, prompt engineering, EHR optimization, healthcare software, retrieval-augmented generation, enterprise transformation, AI strategy, healthcare IT">
-
-    <!-- Schema Markup -->
-    <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "CaseStudy",
-        "name": "From 24 Hours to 2 Minutes: How a Scrappy Team of 6 Built Healthcare's AI Future",
-        "description": "How I worked with AWS & Anthropic to help architect and steer an entire organization's AI trajectory, transforming healthcare support and unlocking millions in funding.",
-        "industry": "Healthcare Software",
-        "primaryTopic": "AI-Powered Enterprise Transformation",
-        "author": {
-            "@type": "Person",
-            "name": "Roan Crabb"
-        },
-        "result": {
-            "@type": "ResultsData",
-            "metrics": [
-                "Response time reduced from 24 hours to 2 minutes",
-                "Triggered company-wide pivot to AI-first development",
-                "Unlocked millions in PE funding",
-                "Secured AWS as strategic partner"
-            ]
-        }
-    }
-    </script>
+        <!-- Additional Meta Tags -->
+        <meta name="keywords" content="healthcare AI, AWS Bedrock, Anthropic Claude, prompt engineering, EHR optimization, healthcare software, retrieval-augmented generation, enterprise transformation, AI strategy, healthcare IT">
 
         <!--[if IE]><meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1'><![endif]-->
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        
+
         <!-- Favicons -->
         <link rel="shortcut icon" href="images/favicon.png">
 
@@ -53,7 +29,7 @@
         <link rel="stylesheet" href="css/owl.carousel.css">
         <link rel="stylesheet" href="css/animate.min.css">
         <link rel="stylesheet" href="css/splitting.css">
-        
+
     </head>
         <body class="appear-animate case-study">
         
@@ -77,7 +53,7 @@
                     <!-- Logo ( * your text or image into link tag *) -->
                     <div class="nav-logo-wrap local-scroll">
                         <a href="index.html" class="logo morphing-text">
-                            <img src="images/logo-white.png" alt="Roan Crabb" width="188" height="37" />
+                            R&nbsp;&nbsp;&nbsp;O&nbsp;&nbsp;&nbsp;A&nbsp;&nbsp;&nbsp;N
                         </a>
                     </div>
                     
@@ -91,9 +67,9 @@
                     <div class="inner-nav desktop-nav">
                         <ul class="clearlist scroll-nav local-scroll">
                             <li class="active"><a href="index.html">Home</a></li>
-                            <li><a href="index.html#services">Our Services</a></li>
-                            <li><a href="index.html#work">Our Work</a></li>
-                            <li><a href="index.html#contact">Contact Us</a></li>
+                            <li><a href="index.html#services">What I Do</a></li>
+                            <li><a href="index.html#work">What I Make</a></li>
+                            <li><a href="index.html#contact">Contact</a></li>
                         </ul>
                     </div>
                     <!-- End Main Menu -->                    

--- a/humble-POC-helps-users-and-defines-AI-future.html
+++ b/humble-POC-helps-users-and-defines-AI-future.html
@@ -5,40 +5,16 @@
         
     <title>From Voice App to Enterprise AI Platform: Designing Healthcare's Future | Roan Crabb</title>
     <meta charset="utf-8">
-    <meta name="description" content="How I led UX design for an 8-figure AI-powered EHR platform that's transforming healthcare across a $100B private equity portfolio. See how we saved healthcare providers 500 hours annually while processing billions of healthcare records.">
+    <meta name="description" content="How I led UX design for an 8-figure AI-powered EHR platform that's transforming healthcare across a $100B private equity portfolio. See how I helped healthcare providers save 500 hours annually while processing billions of records.">
 
     <!-- Open Graph Tags -->
     <meta property="og:title" content="From Voice App to Enterprise AI Platform: Designing Healthcare's Future | Roan Crabb">
-    <meta property="og:description" content="Lead UX Designer for Greenway Clinical Assist - an AI-powered EHR platform saving providers 500 hours annually, supporting 2+ dozen languages, and transforming healthcare delivery at scale.">
+    <meta property="og:description" content="I led UX for Greenway Clinical Assist—an AI-powered EHR platform saving providers 500 hours annually, supporting 2+ dozen languages, and transforming healthcare delivery at scale.">
     <meta property="og:type" content="article">
     <meta property="og:locale" content="en_US">
 
     <!-- Additional Meta Tags -->
     <meta name="keywords" content="healthcare AI platform, EHR UX design, Greenway Clinical Assist, Vista Equity Partners, ambient voice technology, clinical documentation AI, healthcare digital transformation, enterprise healthcare software">
-
-    <!-- Schema Markup -->
-    <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "CaseStudy",
-        "name": "From Voice App to Enterprise AI Platform: Designing Healthcare's Future",
-        "description": "How I led UX design for an 8-figure AI-powered EHR platform that's transforming healthcare across a $100B private equity portfolio.",
-        "industry": "Healthcare Technology",
-        "primaryTopic": "AI-Powered EHR Platform Design",
-        "author": {
-            "name": "Roan Crabb"
-        },
-        "result": {
-            "@type": "ResultsData",
-            "metrics": [
-                "500 hours saved annually per provider",
-                "81% of patients report more focused visits",
-                "8-figure funding secured",
-                "638 practices migrated to platform"
-            ]
-        }
-    }
-    </script>
 
     <!--[if IE]><meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1'><![endif]-->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -60,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Manrope&display=swap" rel="stylesheet">
     
-<script src="https://puc.poecdn.net/authenticated_preview_page/syncedState.bd4eeeb8e8e02052ee92.js"></script></head>
+    </head>
     <body class="appear-animate case-study amb-voice">
     
     <!-- Page Loader -->        
@@ -83,7 +59,7 @@
                 <!-- Logo ( * your text or image into link tag *) -->
                 <div class="nav-logo-wrap local-scroll">
                     <a href="index.html" class="logo morphing-text">
-                        <img src="images/logo-white.png" alt="Roan Crabb" width="188" height="37">
+                        R&nbsp;&nbsp;&nbsp;O&nbsp;&nbsp;&nbsp;A&nbsp;&nbsp;&nbsp;N
                     </a>
                 </div>
                 
@@ -97,9 +73,9 @@
                 <div class="inner-nav desktop-nav">
                     <ul class="clearlist scroll-nav local-scroll">
                         <li class="active"><a href="index.html">Home</a></li>
-                        <li><a href="index.html#services">Our Services</a></li>
-                        <li><a href="index.html#work">Our Work</a></li>
-                        <li><a href="index.html#contact">Contact Us</a></li>
+                        <li><a href="index.html#services">What I Do</a></li>
+                        <li><a href="index.html#work">What I Make</a></li>
+                        <li><a href="index.html#contact">Contact</a></li>
                     </ul>
                 </div>
                 <!-- End Main Menu -->                    

--- a/index.html
+++ b/index.html
@@ -3,16 +3,16 @@
     <head>
         <title>✦Roan Crabb✦ | UX & Product Designer</title>
         <meta charset="utf-8">
-        <meta name="description" content="Roan Crabb transforms complex systems into delightfully simple digital experiences. We combine deep industry expertise with data-driven design to help healthcare and financial organizations thrive in regulated spaces.">
+        <meta name="description" content="Roan Crabb transforms complex systems into delightfully simple digital experiences. I combine deep industry expertise with data-driven design to help healthcare and financial organizations thrive in regulated spaces.">
 
         <!-- Open Graph Tags -->
         <meta property="og:title" content="Roan Crabb - Where Complexity Meets Clarity">
-        <meta property="og:description" content="We turn complex digital challenges into elegant solutions. Bringing together deep industry knowledge and evidence-driven design to create experiences users love and businesses trust.">
+        <meta property="og:description" content="I turn complex digital challenges into elegant solutions, blending deep industry knowledge and evidence-driven design to create experiences users love and businesses trust.">
         <meta property="og:type" content="website">
         <meta property="og:locale" content="en_US">
 
         <!-- Additional Meta Tags -->
-        <meta name="keywords" content="healthcare UX design, financial services UX, digital experience strategy, enterprise UX consulting, regulated industry design, mobile and app UX, conversion rate optimazation, design systems development">
+        <meta name="keywords" content="healthcare UX design, financial services UX, digital experience strategy, enterprise UX consulting, regulated industry design, mobile and app UX, conversion rate optimization, design systems development">
 
         
         <!--[if IE]><meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1'><![endif]-->
@@ -53,7 +53,7 @@
                     <!-- Logo ( * your text or image into link tag *) -->
                     <div class="nav-logo-wrap local-scroll">
                         <a href="index.html" class="logo morph ing-text">
-                            R&nbsp;&nbsp;&nbsp;O&nbsp;&nbsp;&nbsp;A&nbsp;&nbsp;&nbsp;N<!--<img src="images/logo-white.png" alt="Roan Crabb" width="188" height="37" />-->
+                            R&nbsp;&nbsp;&nbsp;O&nbsp;&nbsp;&nbsp;A&nbsp;&nbsp;&nbsp;N
                         </a>
                     </div>
                     


### PR DESCRIPTION
## Summary
- replace the legacy `images/logo-white.png` logo anchors on every case study with the spaced text treatment used on the homepage
- remove the leftover commented image logo from the homepage so the navigation only renders the text-based mark

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c9cd936c10832b9d2c7fc558bc1d47