### PR TITLE
Remove contact forms from case study footers

### DIFF
--- a/cl-doubled-revenue-study.html
+++ b/cl-doubled-revenue-study.html
@@ -753,94 +753,38 @@
 
 
 
-<!-- Footer -->
-            <footer class="page-section bg-dark-lighter light-content footer pb-100 pb-sm-50">
-                <div class="container">
+            <!-- Footer -->
+            <footer class="page-section bg-dark light-content footer">
+                <div class="container" id="contact">
 
-
-                    <!-- Contact Form -->                            
-                    <div class="row">
-                        <div class="col-md-10 offset-md-1 pb-sm-60">
-                            
-                            <form class="form contact-form wow fadeInUpShort" data-wow-delay=".5s" id="contact_form">
-                                <div class="row">
-                                    <h3 class="call-action-1-heading">Ready to start your project? We'd love to help.</h3>
-                                    <div class="call-action-1-decription mb-60 mb-sm-30">
-                                        Have a complex financial platform that needs simplifying? Or maybe just a sneaking suspicion that your user experience could work harder for your business? Let's talk about how we can help you achieve (or exceed) these kinds of results.
-                                    </div>
-                                </div>    
-                                <div class="row">
-                                    <div class="col-md-6">
-                                        <!-- Name -->
-                                        <div class="form-group">
-                                            <label for="name">Name</label>
-                                            <input type="text" name="name" id="name" class="input-lg round form-control" placeholder="Enter your name" pattern=".{3,100}" required aria-required="true">
-                                        </div>
-                                    </div>
-                                    <div class="col-md-6">
-                                        <!-- Email -->
-                                        <div class="form-group">
-                                            <label for="email">Email</label>
-                                            <input type="email" name="email" id="email" class="input-lg round form-control" placeholder="Enter your email" pattern=".{5,100}" required aria-required="true">
-                                        </div>
-                                    </div>
-                                </div>
-                                
-                                <!-- Message -->
-                                <div class="form-group">
-                                    <label for="message">Message</label>
-                                    <textarea name="message" id="message" class="input-lg round form-control" style="height: 130px;" placeholder="Enter your message"></textarea>
-                                </div>
-                                
-                                <div class="row">
-                                    <div class="col-sm-6">
-                                        <!-- Inform Tip -->
-                                        <div class="form-tip pt-20 pt-sm-0 mb-sm-20">
-                                            All fields are required
-                                        </div>
-                                    </div>
-                                    <div class="col-sm-6">
-                                        <!-- Send Button -->
-                                        <div class="text-end pt-10">
-                                            <button class="submit_btn btn btn-mod btn-w btn-large btn-round morphing-bg" id="submit_btn" aria-controls="result">
-                                                Send Message
-                                            </button>
-                                        </div>
-                                    </div>
-                                </div>
-                            
-                            <div id="result" role="region" aria-live="polite" aria-atomic="true"></div>
-                            
-                            </form>
-                            
-                        </div>
-                    </div>
-                    <!-- End Contact Form -->
 
                     <!-- Footer Text -->
                     <div class="footer-text">
-                        
+
                         <!-- Copyright -->
                         <div class="footer-copy">
-                            <a href="index.html">© Roan Crabb 2025</a>.
+                            <a href="index.html">© Roan Crabb 2025</a> |  <a href="https://www.linkedin.com/in/roan-crabb/">LinkedIn</a>
                         </div>
                         <!-- End Copyright -->
-                        
+
                         <div class="footer-made">
-                            You have exceptional scrolling technique.
+                            Don't forget to stretch and hydrate. That was a long scroll down.
                         </div>
-                        
+
                     </div>
-                    <!-- End Footer Text -->                     
-                 </div>                 
+                    <!-- End Footer Text -->
+
+                 </div>
+
                  <!-- Top Link -->
                  <div class="local-scroll">
                      <a href="#top" class="link-to-top"><i class="link-to-top-icon"></i><span class="sr-only">Scroll to top</span></a>
                  </div>
                  <!-- End Top Link -->
-                 
+
             </footer>
             <!-- End Footer -->
+
         
         </div>
         <!-- End Page Wrap -->
@@ -866,7 +810,6 @@
         <script src="js/morphext.js"></script>
         <script src="js/typed.min.js"></script>
         <script src="js/all.js"></script>
-        <script src="js/contact-form.js"></script>
         <script src="js/jquery.ajaxchimp.min.js"></script>
         <script src="js/objectFitPolyfill.min.js"></script>
         <script src="js/splitting.min.js"></script>

--- a/cl-organic-foundation-study.html
+++ b/cl-organic-foundation-study.html
@@ -604,94 +604,40 @@
             <!-- End Divider -->
            </main>
             
+
             <!-- Footer -->
-            <footer class="page-section bg-dark-lighter light-content footer pb-100 pb-sm-50">
-                <div class="container">
+            <footer class="page-section bg-dark light-content footer">
+                <div class="container" id="contact">
 
-
-                    <!-- Contact Form -->                            
-                    <div class="row">
-                        <div class="col-md-10 offset-md-1 pb-sm-60">
-                            
-                            <form class="form contact-form wow fadeInUpShort" data-wow-delay=".5s" id="contact_form">
-                                <div class="row">
-                                    <h3 class="call-action-1-heading">Ready to start your project? We'd love to help.</h3>
-                                    <div class="call-action-1-decription mb-60 mb-sm-30">
-                                        Have a complex platform that needs transformation? Or a business model ready for exponential growth? Let's discuss how strategic UX and content can drive your results.
-                                    </div>
-                                </div>    
-                                <div class="row">
-                                    <div class="col-md-6">
-                                        <!-- Name -->
-                                        <div class="form-group">
-                                            <label for="name">Name</label>
-                                            <input type="text" name="name" id="name" class="input-lg round form-control" placeholder="Enter your name" pattern=".{3,100}" required aria-required="true">
-                                        </div>
-                                    </div>
-                                    <div class="col-md-6">
-                                        <!-- Email -->
-                                        <div class="form-group">
-                                            <label for="email">Email</label>
-                                            <input type="email" name="email" id="email" class="input-lg round form-control" placeholder="Enter your email" pattern=".{5,100}" required aria-required="true">
-                                        </div>
-                                    </div>
-                                </div>
-                                
-                                <!-- Message -->
-                                <div class="form-group">
-                                    <label for="message">Message</label>
-                                    <textarea name="message" id="message" class="input-lg round form-control" style="height: 130px;" placeholder="Enter your message"></textarea>
-                                </div>
-                                
-                                <div class="row">
-                                    <div class="col-sm-6">
-                                        <!-- Inform Tip -->
-                                        <div class="form-tip pt-20 pt-sm-0 mb-sm-20">
-                                            All fields are required
-                                        </div>
-                                    </div>
-                                    <div class="col-sm-6">
-                                        <!-- Send Button -->
-                                        <div class="text-end pt-10">
-                                            <button class="submit_btn btn btn-mod btn-w btn-large btn-round morphing-bg" id="submit_btn" aria-controls="result">
-                                                Send Message
-                                            </button>
-                                        </div>
-                                    </div>
-                                </div>
-                            
-                            <div id="result" role="region" aria-live="polite" aria-atomic="true"></div>
-                            
-                            </form>
-                            
-                        </div>
-                    </div>
-                    <!-- End Contact Form -->
 
                     <!-- Footer Text -->
                     <div class="footer-text">
-                        
+
                         <!-- Copyright -->
                         <div class="footer-copy">
-                            <a href="index.html">© Roan Crabb 2025</a>.
+                            <a href="index.html">© Roan Crabb 2025</a> |  <a href="https://www.linkedin.com/in/roan-crabb/">LinkedIn</a>
                         </div>
                         <!-- End Copyright -->
-                        
+
                         <div class="footer-made">
-                            You have exceptional scrolling technique.
+                            Don't forget to stretch and hydrate. That was a long scroll down.
                         </div>
-                        
+
                     </div>
-                    <!-- End Footer Text -->                     
-                 </div>                 
+                    <!-- End Footer Text -->
+
+                 </div>
+
                  <!-- Top Link -->
                  <div class="local-scroll">
                      <a href="#top" class="link-to-top"><i class="link-to-top-icon"></i><span class="sr-only">Scroll to top</span></a>
                  </div>
                  <!-- End Top Link -->
-                 
+
             </footer>
             <!-- End Footer -->
+
+
         
         </div>
         <!-- End Page Wrap -->
@@ -717,7 +663,6 @@
         <script src="js/morphext.js"></script>
         <script src="js/typed.min.js"></script>
         <script src="js/all.js"></script>
-        <script src="js/contact-form.js"></script>
         <script src="js/jquery.ajaxchimp.min.js"></script>
         <script src="js/objectFitPolyfill.min.js"></script>
         <script src="js/splitting.min.js"></script>

--- a/gen-ai-healthcare-support-bot-study.html
+++ b/gen-ai-healthcare-support-bot-study.html
@@ -591,93 +591,37 @@
                            </main>
             
             <!-- Footer -->
-            <footer class="page-section bg-dark-lighter light-content footer pb-100 pb-sm-50">
-                <div class="container">
+            <footer class="page-section bg-dark light-content footer">
+                <div class="container" id="contact">
 
-
-                    <!-- Contact Form -->                            
-                    <div class="row">
-                        <div class="col-md-10 offset-md-1 pb-sm-60">
-                            
-                            <form class="form contact-form wow fadeInUpShort" data-wow-delay=".5s" id="contact_form">
-                                <div class="row">
-                                    <h3 class="call-action-1-heading">Ready to start your project? We'd love to help.</h3>
-                                    <div class="call-action-1-decription mb-60 mb-sm-30">
-                                        Have a complex financial platform that needs simplifying? Or maybe just a sneaking suspicion that your user experience could work harder for your business? Let's talk about how we can help you achieve (or exceed) these kinds of results.
-                                    </div>
-                                </div>    
-                                <div class="row">
-                                    <div class="col-md-6">
-                                        <!-- Name -->
-                                        <div class="form-group">
-                                            <label for="name">Name</label>
-                                            <input type="text" name="name" id="name" class="input-lg round form-control" placeholder="Enter your name" pattern=".{3,100}" required aria-required="true">
-                                        </div>
-                                    </div>
-                                    <div class="col-md-6">
-                                        <!-- Email -->
-                                        <div class="form-group">
-                                            <label for="email">Email</label>
-                                            <input type="email" name="email" id="email" class="input-lg round form-control" placeholder="Enter your email" pattern=".{5,100}" required aria-required="true">
-                                        </div>
-                                    </div>
-                                </div>
-                                
-                                <!-- Message -->
-                                <div class="form-group">
-                                    <label for="message">Message</label>
-                                    <textarea name="message" id="message" class="input-lg round form-control" style="height: 130px;" placeholder="Enter your message"></textarea>
-                                </div>
-                                
-                                <div class="row">
-                                    <div class="col-sm-6">
-                                        <!-- Inform Tip -->
-                                        <div class="form-tip pt-20 pt-sm-0 mb-sm-20">
-                                            All fields are required
-                                        </div>
-                                    </div>
-                                    <div class="col-sm-6">
-                                        <!-- Send Button -->
-                                        <div class="text-end pt-10">
-                                            <button class="submit_btn btn btn-mod btn-w btn-large btn-round morphing-bg" id="submit_btn" aria-controls="result">
-                                                Send Message
-                                            </button>
-                                        </div>
-                                    </div>
-                                </div>
-                            
-                            <div id="result" role="region" aria-live="polite" aria-atomic="true"></div>
-                            
-                            </form>
-                            
-                        </div>
-                    </div>
-                    <!-- End Contact Form -->
 
                     <!-- Footer Text -->
                     <div class="footer-text">
-                        
+
                         <!-- Copyright -->
                         <div class="footer-copy">
-                            <a href="index.html">© Roan Crabb 2025</a>.
+                            <a href="index.html">© Roan Crabb 2025</a> |  <a href="https://www.linkedin.com/in/roan-crabb/">LinkedIn</a>
                         </div>
                         <!-- End Copyright -->
-                        
+
                         <div class="footer-made">
-                            You have exceptional scrolling technique.
+                            Don't forget to stretch and hydrate. That was a long scroll down.
                         </div>
-                        
+
                     </div>
-                    <!-- End Footer Text -->                     
-                 </div>                 
+                    <!-- End Footer Text -->
+
+                 </div>
+
                  <!-- Top Link -->
                  <div class="local-scroll">
                      <a href="#top" class="link-to-top"><i class="link-to-top-icon"></i><span class="sr-only">Scroll to top</span></a>
                  </div>
                  <!-- End Top Link -->
-                 
+
             </footer>
             <!-- End Footer -->
+
         
         </div>
         <!-- End Page Wrap -->
@@ -703,7 +647,6 @@
         <script src="js/morphext.js"></script>
         <script src="js/typed.min.js"></script>
         <script src="js/all.js"></script>
-        <script src="js/contact-form.js"></script>
         <script src="js/jquery.ajaxchimp.min.js"></script>
         <script src="js/objectFitPolyfill.min.js"></script>
         <script src="js/splitting.min.js"></script>

--- a/humble-POC-helps-users-and-defines-AI-future.html
+++ b/humble-POC-helps-users-and-defines-AI-future.html
@@ -718,94 +718,38 @@
         
 
 
-<!-- Footer -->
-        <footer class="page-section bg-dark-lighter light-content footer pb-100 pb-sm-50">
-            <div class="container">
+            <!-- Footer -->
+            <footer class="page-section bg-dark light-content footer">
+                <div class="container" id="contact">
 
 
-                <!-- Contact Form -->                            
-                <div class="row">
-                    <div class="col-md-10 offset-md-1 pb-sm-60">
-                        
-                        <form class="form contact-form wow fadeInUpShort" data-wow-delay=".5s" id="contact_form">
-                            <div class="row">
-                                <h3 class="call-action-1-heading">Ready to start your project? We'd love to help.</h3>
-                                <div class="call-action-1-decription mb-60 mb-sm-30">
-                                    Have a complex healthcare platform that needs transforming? Or maybe you're looking to leverage AI to create the next generation of enterprise software? Let's talk about how we can help you achieve (or exceed) these kinds of results.
-                                </div>
-                            </div>    
-                            <div class="row">
-                                <div class="col-md-6">
-                                    <!-- Name -->
-                                    <div class="form-group">
-                                        <label for="name">Name</label>
-                                        <input type="text" name="name" id="name" class="input-lg round form-control" placeholder="Enter your name" pattern=".{3,100}" required="" aria-required="true">
-                                    </div>
-                                </div>
-                                <div class="col-md-6">
-                                    <!-- Email -->
-                                    <div class="form-group">
-                                        <label for="email">Email</label>
-                                        <input type="email" name="email" id="email" class="input-lg round form-control" placeholder="Enter your email" pattern=".{5,100}" required="" aria-required="true">
-                                    </div>
-                                </div>
-                            </div>
-                            
-                            <!-- Message -->
-                            <div class="form-group">
-                                <label for="message">Message</label>
-                                <textarea name="message" id="message" class="input-lg round form-control" style="height: 130px;" placeholder="Enter your message"></textarea>
-                            </div>
-                            
-                            <div class="row">
-                                <div class="col-sm-6">
-                                    <!-- Inform Tip -->
-                                    <div class="form-tip pt-20 pt-sm-0 mb-sm-20">
-                                        All fields are required
-                                    </div>
-                                </div>
-                                <div class="col-sm-6">
-                                    <!-- Send Button -->
-                                    <div class="text-end pt-10">
-                                        <button class="submit_btn btn btn-mod btn-w btn-large btn-round morphing-bg" id="submit_btn" aria-controls="result">
-                                            Send Message
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
-                        
-                        <div id="result" role="region" aria-live="polite" aria-atomic="true"></div>
-                        
-                        </form>
-                        
-                    </div>
-                </div>
-                <!-- End Contact Form -->
+                    <!-- Footer Text -->
+                    <div class="footer-text">
 
-                <!-- Footer Text -->
-                <div class="footer-text">
-                    
-                    <!-- Copyright -->
-                    <div class="footer-copy">
-                        <a href="index.html">© Roan Crabb 2025</a>.
+                        <!-- Copyright -->
+                        <div class="footer-copy">
+                            <a href="index.html">© Roan Crabb 2025</a> |  <a href="https://www.linkedin.com/in/roan-crabb/">LinkedIn</a>
+                        </div>
+                        <!-- End Copyright -->
+
+                        <div class="footer-made">
+                            Don't forget to stretch and hydrate. That was a long scroll down.
+                        </div>
+
                     </div>
-                    <!-- End Copyright -->
-                    
-                    <div class="footer-made">
-                        You have exceptional scrolling technique.
-                    </div>
-                    
-                </div>
-                <!-- End Footer Text -->                     
-             </div>                 
-             <!-- Top Link -->
-             <div class="local-scroll">
-                 <a href="#top" class="link-to-top"><i class="link-to-top-icon"></i><span class="sr-only">Scroll to top</span></a>
-             </div>
-             <!-- End Top Link -->
-             
-        </footer>
-        <!-- End Footer -->
+                    <!-- End Footer Text -->
+
+                 </div>
+
+                 <!-- Top Link -->
+                 <div class="local-scroll">
+                     <a href="#top" class="link-to-top"><i class="link-to-top-icon"></i><span class="sr-only">Scroll to top</span></a>
+                 </div>
+                 <!-- End Top Link -->
+
+            </footer>
+            <!-- End Footer -->
+
     
     
     <!-- End Page Wrap -->
@@ -831,7 +775,6 @@
     <script src="js/morphext.js"></script>
     <script src="js/typed.min.js"></script>
     <script src="js/all.js"></script>
-    <script src="js/contact-form.js"></script>
     <script src="js/jquery.ajaxchimp.min.js"></script>
     <script src="js/objectFitPolyfill.min.js"></script>
     <script src="js/splitting.min.js"></script>


### PR DESCRIPTION
## Summary
- replace each case study footer with the streamlined index-style contact block
- remove contact form assets and PHP references from the case study pages

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68caf6c52c28832ba0f38dd1fd3464e6