### PR TITLE
Update case study contact link targets and hero title

### DIFF
--- a/cl-doubled-revenue-study.html
+++ b/cl-doubled-revenue-study.html
@@ -70,7 +70,7 @@
                             <li class="active"><a href="index.html">Home</a></li>
                             <li><a href="index.html#services">What I Do</a></li>
                             <li><a href="index.html#work">What I Make</a></li>
-                            <li><a href="index.html#contact">Contact</a></li>
+                            <li><a href="#contact">Contact</a></li>
                         </ul>
                     </div>
                     <!-- End Main Menu -->                    

--- a/cl-organic-foundation-study.html
+++ b/cl-organic-foundation-study.html
@@ -69,7 +69,7 @@
                             <li class="active"><a href="index.html">Home</a></li>
                             <li><a href="index.html#services">What I Do</a></li>
                             <li><a href="index.html#work">What I Make</a></li>
-                            <li><a href="index.html#contact">Contact</a></li>
+                            <li><a href="#contact">Contact</a></li>
                         </ul>
                     </div>
                     <!-- End Main Menu -->                    

--- a/gen-ai-healthcare-support-bot-study.html
+++ b/gen-ai-healthcare-support-bot-study.html
@@ -69,7 +69,7 @@
                             <li class="active"><a href="index.html">Home</a></li>
                             <li><a href="index.html#services">What I Do</a></li>
                             <li><a href="index.html#work">What I Make</a></li>
-                            <li><a href="index.html#contact">Contact</a></li>
+                            <li><a href="#contact">Contact</a></li>
                         </ul>
                     </div>
                     <!-- End Main Menu -->                    

--- a/humble-POC-helps-users-and-defines-AI-future.html
+++ b/humble-POC-helps-users-and-defines-AI-future.html
@@ -70,7 +70,7 @@
                         <li class="active"><a href="index.html">Home</a></li>
                         <li><a href="index.html#services">What I Do</a></li>
                         <li><a href="index.html#work">What I Make</a></li>
-                        <li><a href="index.html#contact">Contact</a></li>
+                        <li><a href="#contact">Contact</a></li>
                     </ul>
                 </div>
                 <!-- End Main Menu -->                    

--- a/index.html
+++ b/index.html
@@ -365,7 +365,7 @@
                         <div class="text-center mb-80 mb-sm-50">
                             <div class="row">
                                 <div class="col-sm-6 offset-sm-3">
-                                    <h2 class="section-title">Design That Delivers</h2>
+                                    <h2 class="section-title">What I Make</h2>
                                     <p class="section-title-descr">
                                         No hypothetical redesigns here - just products serving millions with measurable impact.
                                     </p>


### PR DESCRIPTION
## Summary
- rename the case studies section heading on the home page to "What I Make"
- point the Contact navigation item on each case study page to the on-page contact anchor instead of the home page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb39104f6c832b8aec77c16196f5eb