### PR TITLE
Fix spelling and grammar issues in site content

### DIFF
--- a/gen-ai-healthcare-support-bot-study.html
+++ b/gen-ai-healthcare-support-bot-study.html
@@ -238,7 +238,7 @@
                                                     <ol>
                                                         <li><strong>Prove AI could transform our business</strong> - Success here would unlock millions in PE funding and pivot our entire product roadmap to AI-first development</li>
                                                         <li><strong>Build something that understood healthcare context</strong> - A system that could parse the complex relationships between clinical workflows, billing processes, our software platforms, and the technical documentation that supports them</li>
-                                                        <li><strong>Ship it for our major conference</strong> - We were scheduled to demo this live at an huge upcoming event. Nothing like a public deadline to focus the mind and kick the public speaking jitters into overdrive</li>
+                                                        <li><strong>Ship it for our major conference</strong> - We were scheduled to demo this live at a huge upcoming event. Nothing like a public deadline to focus the mind and kick the public speaking jitters into overdrive</li>
                                                     </ol>
                                                 </div>
                                                 <div class="col-lg-5 offset-lg-1  wow fadeScaleIn" data-wow-duration="1.5s">

--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@
                                     </div>
                                 <h3 class="services-title">UX, UI & Product Design</h3>
                                 <div class="services-descr">
-                                    <p>From C-suite vision to high-volume handling thumb-friendly interfaces. 25+ years designing products that actually launch and work. Specialized in mobile-first experiences because that's where many users live.</p>
+                                    <p>From C-suite vision to high-volume, thumb-friendly interfaces. 25+ years designing products that actually launch and work. Specialized in mobile-first experiences because that's where many users live.</p>
 
                                     
                                 </div>
@@ -308,7 +308,7 @@
                                 </div>
                                 <ul class="text-start wow mx-auto linesAnimIn" data-splitting="lines" style="width: fit-content;">
                                     <li>Created prototypes & assets that helped secure 8-figure funding from $100B+ PE firm</li>
-                                    <li>Managed $10M+ annual ad-spend budgets and it's optimization</li>
+                                    <li>Managed $10M+ annual ad-spend budgets and its optimization</li>
                                     <li>Led 25+ person teams across design, dev, and content creation</li>
                                     <li>Collaborated with Fortune 500 partners (AWS, JPMorgan, Anthropic)</li>
                                     <li>Bridge technical constraints with business requirements daily</li>
@@ -347,7 +347,11 @@
                                     <div class="banner-content wow fadeInUpShort" data-wow-duration="1.2s">
                                         <h3 class="banner-heading">Great design happens through powerful partnerships</h3>
                                         <div class="banner-decription local-scroll">
-                                            I've learned so much in working with industry giants and delivering when it matters most. This happens by architecting AI solutions directly with Anthropic's research team & AWS Bedrock engineers to implement Claude in production healthcare environments, I've been the designer folks lean on when the stakes are high. Working within Vista Equity's massive portfolio and alongside AI and software leaders has given me unique insights into what actually moves the needle at scale. After training hundreds of employees across a variety of organizations and speaking at major conferences, I've learned what separates good UX from transformative design. 
+                                            I've learned so much in working with industry giants and delivering when it matters most.
+                                            This happens by architecting AI solutions directly with Anthropic's research team & AWS Bedrock engineers to implement Claude in production healthcare environments.
+                                            I've been the designer folks lean on when the stakes are high.
+                                            Working within Vista Equity's massive portfolio and alongside AI and software leaders has given me unique insights into what actually moves the needle at scale.
+                                            After training hundreds of employees across a variety of organizations and speaking at major conferences, I've learned what separates good UX from transformative design.
                                         </div>
                                         
                                     </div>
@@ -429,7 +433,7 @@
                                 </div>
                                 
                                 <div class="post-prev-text">
-                                    When you're burning $25,000 daily on paid traffic, finding growth feels impossible. CreditLoan.com was trapped in a PPC death spiral. They were profitable but bleeding money. Through strategic UX transformation and building a world-class content engine, we didn't just reduce PPC dependency and cost, we increased both transactions and revenue by over 300% in just 6 months. Keywords ranked jumped from 3,000 to 20,000 overnight at launch, eventually reaching 70,000+. The framework proved so effective that we replicated it across multiple portfolio brands, with sister companies even licensing our conversion systems through revenue-share agreements.
+                                    When you're burning $25,000 daily on paid traffic, finding growth feels impossible. CreditLoan.com was trapped in a PPC death spiral. They were profitable but bleeding money. Through strategic UX transformation and building a world-class content engine, we didn't just reduce PPC dependency and cost, we increased both transactions and revenue by over 300% in just 6 months. Keyword rankings jumped from 3,000 to 20,000 overnight at launch, eventually reaching 70,000+. The framework proved so effective that we replicated it across multiple portfolio brands, with sister companies even licensing our conversion systems through revenue-share agreements.
                                 </div>
                                 
                                 <div class="post-prev-more">
@@ -989,7 +993,7 @@
                                         <p>...Roan taught me good design isn't just making things pretty. It's making things work for users who really don't care about your design system. Best advice I got: 'If you can't explain your design decision in terms of user behavior or business metrics, you're just decorating'...
                                         </p>
                                         <footer class="testimonial-author mt-50 mt-sm-20">
-                                            — Harshpreet Singh | Senior Ux Designer, Greenway Health
+                                            — Harshpreet Singh | Senior UX Designer, Greenway Health
                                         </footer>
                                     </blockquote>
                                 </div>


### PR DESCRIPTION
## Summary
- clarify homepage copy by tightening service descriptions and correcting possessive usage
- rework the partnerships section text for readability and adjust case study metrics wording
- capitalize testimonial job title correctly and fix an article typo in the AI support case study

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db198e8574832b9eed3998020160e9