### PR TITLE
Ensure mobile nav outside click closes only in mobile mode

### DIFF
--- a/js/all.js
+++ b/js/all.js
@@ -238,8 +238,10 @@
                      
         });
         
-        $(document).on("click", function(event){            
-            if ($(window).width() <= 1024) {
+        $(document).on("click", function(event){
+            var isMobileNavActive = $(".main-nav").hasClass("mobile-on") || (mobile_nav.hasClass("active") && desktop_nav.hasClass("js-opened"));
+
+            if (isMobileNavActive) {
                 var $trigger = $(".main-nav");
                 if ($trigger !== event.target && !$trigger.has(event.target).length) {
                     desktop_nav.slideUp("slow", "easeOutExpo").removeClass("js-opened");


### PR DESCRIPTION
## Summary
- ensure the outside click handler only collapses the nav when the main navigation is in mobile mode or opened via the mobile toggle
- keep the desktop navigation visible at tablet breakpoints by avoiding window-width-only checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690cd532f9ec832b90e37f00545b18e7